### PR TITLE
Remove Non-ASCII character preventing import

### DIFF
--- a/microscPSF/microscPSF.py
+++ b/microscPSF/microscPSF.py
@@ -17,7 +17,7 @@ References:
 
 2. Gibson, S. & Lanni, F. "Experimental test of an analytical model of
    aberration in an oil-immersion objective lens used in three-dimensional
-   light microscopy", J. Opt. Soc. Am. A 9, 154–166 (1992), [Originally 
+   light microscopy", J. Opt. Soc. Am. A 9, 154-166 (1992), [Originally
    published in J. Opt. Soc. Am. A 8, 1601-1613 (1991)].
 
 3. Kirshner et al, "3-D PSF fitting for fluorescence microscopy: implementation 


### PR DESCRIPTION
this is awesome, thank you for doing this.  i had a Syntax error when trying to import, due to the dash in one of the references in the comments...
`SyntaxError: Non-ASCII character '\xe2' in file microscPSF.py on line 21, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`
just replacing with a new "regular" dash character fixed it for me...